### PR TITLE
feat(status): Add a url to a status graph site

### DIFF
--- a/src/commands/utils/status.ts
+++ b/src/commands/utils/status.ts
@@ -32,6 +32,10 @@ export async function execute(
 ) {
   const buttonsRow = new ActionRowBuilder<ButtonBuilder>().setComponents(
     new ButtonBuilder()
+      .setURL('http://status.kawaii-programer.online') //Currently a placeholder, but I will make it work soon.
+      .setLabel('🌿 Веб-Статус')
+      .setStyle(ButtonStyle.Link),
+    new ButtonBuilder()
       .setURL('https://github.com/richardscull/RichardsMusicBot')
       .setLabel('📂 GitHub')
       .setStyle(ButtonStyle.Link)


### PR DESCRIPTION
Planning to set up an Uptime Kuma on mine hosting. So it's a placeholder for now, but okay. 